### PR TITLE
some minor cleanups

### DIFF
--- a/lib/BluetoothOTA/library.json
+++ b/lib/BluetoothOTA/library.json
@@ -21,6 +21,10 @@
   "platforms": "*",
   "dependencies": [
     { "name": "Update" },
-    { "name": "ESP32 BLE Arduino" }
+    { "name": "ESP32 BLE Arduino" },
+    {
+      "name": "arduino-fsm",
+      "version": "https://github.com/geeksville/arduino-fsm.git"
+    }
   ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,8 +21,8 @@ framework = arduino
 board_build.partitions = partition-table.csv
 
 ; note: we add src to our include search path so that lmic_project_config can override
-; FIXME fix dependencies on arduino-fsm
-build_flags = -Wall -Wextra -Wno-missing-field-initializers -I.pio/libdeps/esp32/arduino-fsm -Isrc -Os -Wl,-Map,.pio/build/esp32/output.map -DAXP_DEBUG_PORT=Serial 
+; FIXME: fix lib/BluetoothOTA dependency back on src/ so we can remove -Isrc
+build_flags = -Wall -Wextra -Wno-missing-field-initializers -Isrc -Os -Wl,-Map,.pio/build/esp32/output.map -DAXP_DEBUG_PORT=Serial
 
 ; not needed included in ttgo-t-beam board file
 ; also to use PSRAM https://docs.platformio.org/en/latest/platforms/espressif32.html#external-ram-psram
@@ -55,14 +55,16 @@ debug_tool = jlink
 
 debug_init_break = tbreak setup
 
+; Note: some libraries are specified by #ID where there are conflicting library
+; names.
 lib_deps =
   https://github.com/geeksville/RadioHead.git
-  TinyGPSPlus
+  1655 ; TinyGPSPlus
   https://github.com/geeksville/esp8266-oled-ssd1306.git ; ESP8266_SSD1306 
   AXP202X_Library
   SPI
-  OneButton
-  CRC32 ; explicitly needed because dependency is missing in the ble ota update lib
+  1260 ; OneButton
+  1202 ; CRC32, explicitly needed because dependency is missing in the ble ota update lib
   Wire ; explicitly needed here because the AXP202 library forgets to add it
   https://github.com/geeksville/arduino-fsm.git 
 

--- a/src/PowerFSM.h
+++ b/src/PowerFSM.h
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include "Fsm.h"
+#include <Fsm.h>
 
 // See sw-design.md for documentation
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -510,7 +510,7 @@ void Screen::setOn(bool on)
     }
 }
 
-static void screen_print(const char *text, uint8_t x, uint8_t y, uint8_t alignment)
+void screen_print(const char *text, uint8_t x, uint8_t y, uint8_t alignment)
 {
     DEBUG_MSG(text);
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -3,6 +3,7 @@
 #include "PeriodicTask.h"
 
 void screen_print(const char * text);
+void screen_print(const char * text, uint8_t x, uint8_t y, uint8_t alignment);
 
 
 // Show the bluetooth PIN screen


### PR DESCRIPTION
* Suppress warnings about conflicting library names in platformio.ini by
  explicitly picking the libraries by id that we want.
* fix unused static function warning by making it not static ;)
* hopefully fix the broken platformio dependency detection for fsm that
  shows up in the CI builds?

Tested: `pio run` builds.